### PR TITLE
Add `OWNERS_ALIASES` sync. script to README.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,5 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
-
-approvers: &owner
+approvers:  &owner
   - cspi-qe-ocp-lp
 options: {}
 reviewers: *owner

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,13 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
+# Read `README.md` on how to update this file!!!
+aliases:
+  cspi-qe-ocp-lp:
+    - Sau1506mya
+    - amp-rh
+    - oharan2
+    - shakyav
+    - dfrazzette
+    - danalanerh
+    - sg-rh
+    - etirta
+    - tanfengshuang

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # interop-testing
 Repository for interop testing between operators
+
+## The `OWNERS` and `OWNERS_ALIASES`
+The `OWNERS` file will be synced to https://github.com/openshift/release/blob/main/ci-operator/config/RedHatQE/interop-testing/OWNERS.
+It may contain Group Aliases from https://github.com/openshift/release/blob/main/OWNERS_ALIASES, as long as the `OWNERS_ALIASES` is updated with this script:
+```shell
+# Run this on the `root` of `git` local Working Tree.
+(
+    curl -fsSL 'https://raw.githubusercontent.com/openshift/release/main/OWNERS_ALIASES' |
+    yq -o json '.aliases' |
+    jq --argjson names "$(yq -o json 'explode(.) | [.approvers[], .reviewers[]] | unique' OWNERS)" '
+        {"aliases": with_entries(select(.key | IN($names[])))}
+    ' |
+    yq -p json -o yaml '
+        . head_comment=(
+            "See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases" +
+            "\nRead `README.md` on how to update this file!!!"
+        )
+    '
+) > OWNERS_ALIASES
+```


### PR DESCRIPTION
## Description
Updating the `OWNERS_ALIASES` file in order for `OWNERS` file to be able to include the Group Aliases from
https://github.com/openshift/release/blob/main/OWNERS_ALIASES.

Use simple script to update the `OWNERS_ALIASES` by using https://github.com/openshift/release/blob/main/OWNERS_ALIASES as source of truth.

