### PR TITLE
README: Update `OWNERS_ALIASES` sync. script.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,9 +4,4 @@ approvers:  &owner
 options: {}
 reviewers: *owner
 emeritus_approvers:
-  - dbasunag        # 2026-03-28
-  - dkeler          # 2026-03-28
-  - lukas-bednar    # 2026-03-28
-  - myakove         # 2026-03-28
-  - rabin-io        # 2026-03-28
-  - rnetser         # 2026-03-28
+  - zzz--emeritus

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,3 +11,10 @@ aliases:
     - sg-rh
     - etirta
     - tanfengshuang
+  zzz--emeritus:
+    - dbasunag     # 2026-03-28
+    - dkeler       # 2026-03-28
+    - lukas-bednar # 2026-03-28
+    - myakove      # 2026-03-28
+    - rabin-io     # 2026-03-28
+    - rnetser      # 2026-03-28

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # interop-testing
-Repository for interop testing between operators
+Repository for Inter-operability Testing between Layered Products (Operators).
 
 ## The `OWNERS` and `OWNERS_ALIASES`
 The `OWNERS` file will be synced to https://github.com/openshift/release/blob/main/ci-operator/config/RedHatQE/interop-testing/OWNERS.
@@ -7,16 +7,20 @@ It may contain Group Aliases from https://github.com/openshift/release/blob/main
 ```shell
 # Run this on the `root` of `git` local Working Tree.
 (
+    1>> OWNERS_ALIASES; exec 3< <(cat OWNERS_ALIASES); wait $!
     curl -fsSL 'https://raw.githubusercontent.com/openshift/release/main/OWNERS_ALIASES' |
     yq -o json '.aliases' |
-    jq --argjson names "$(yq -o json 'explode(.) | [.approvers[], .reviewers[]] | unique' OWNERS)" '
-        {"aliases": with_entries(select(.key | IN($names[])))}
-    ' |
-    yq -p json -o yaml '
-        . head_comment=(
-            "See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases" +
-            "\nRead `README.md` on how to update this file!!!"
-        )
-    '
-) > OWNERS_ALIASES
+    jq --argjson names "$(yq -o json '
+        explode(.) | [.approvers[], .reviewers[], .emeritus_approvers[]] | unique
+    ' OWNERS)" 'with_entries(select(.key | IN($names[])))' |
+    yq -p json -o yaml eval '{"aliases": .}' |
+    yq eval-all '(select(fileIndex==0) * select(fileIndex==1)) | . head_comment=""' /dev/fd/3 - |
+    column -t -s '#' -o '#' |
+    sed \
+        -e '1i# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases' \
+        -e '1i# Read `README.md` on how to update this file!!!' \
+        -e 's/ *#$//' \
+    1> OWNERS_ALIASES
+    exec 3<&-
+)
 ```


### PR DESCRIPTION
## Description
The `OWNERS_ALIASES` file should maintain its local Group aliases even after synchronizing with `openshift/release`.
